### PR TITLE
chore: update build process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: Build
+
+on: [pull_request]
+
+jobs:
+  build:
+    name: Build Gatsby site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2.3.1
+
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '16.x'
+
+      - name: Install Project Dependencies
+        run: yarn install
+
+      - name: Build
+        run: yarn build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,12 +15,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '10.x'
-
-      - name: Install Global Dependencies
-        run: |
-          npm install -g yarn
-          npm install -g gatsby-cli@2.12.34
+          node-version: '16.x'
 
       - name: Install Project Dependencies
         run: yarn install


### PR DESCRIPTION
Based on @louh's #97. Upgrades Node to 16.x in the GitHub Workflow, revises it to build on PRs, publish on merge to ~master~ main.