### PR TITLE
Remove source of flashing

### DIFF
--- a/lib/ui/templates/BlogPostTpl.js
+++ b/lib/ui/templates/BlogPostTpl.js
@@ -12,7 +12,11 @@ export default class BlogPostTpl extends Component {
     const readingTime = Math.random() * 300;
     if (typeof window !== "undefined") {
       this.tick = this.tick.bind(this);
-      setInterval(this.tick, 3000);
+      //setInterval(this.tick, 3000);
+      // Note the above line was removed because it was causing
+      // the page to flash every 3 seconds.
+      // See https://github.com/BadIdeaFactory/biffud.com/issues/99
+      // for further details.
     }
     this.state = {
       readingTime


### PR DESCRIPTION
There are more in depth fixes but in the short term this flash is a liability for anybody prone to seizures.

This disables our constantly updating reading time, but that's OK since it was causing harm.

We'll make a longer term fix that restores the functionality at a later date.

Related to Issue #99