### PR TITLE
feat(people): add bluesky, mastodon and website frontmatter

### DIFF
--- a/lib/ui/components/icons/Icon.js
+++ b/lib/ui/components/icons/Icon.js
@@ -2,6 +2,8 @@
 import { shape, string } from "prop-types";
 import React from "react";
 import styled from "styled-components";
+import { FaLink } from "react-icons/fa";
+import { SiBluesky, SiMastodon } from "react-icons/si";
 
 import { defaultThm } from "ui/themes";
 import { icomoon } from "assets/fonts";
@@ -30,11 +32,47 @@ const IconEl = styled.i`
   }
 `;
 
-const Icon = props => (
-  <IconEl {...props} className={`icon-${props.name} `}>
-    {props.text ? <span>{props.text}</span> : null}
-  </IconEl>
-);
+const Icon = props => {
+  switch (props.name) {
+    // I'm not going to generate a new IcoMoon font for these
+    // and in any case they don't have Bluesky or Mastdon readily
+    // available anyway. Generating icons with react-icons is 100%
+    // more flexible
+    case 'bluesky':
+      return (
+        <IconEl {...props} className={`icon-${props.name}`} style={{
+          top: '1px',
+          position: 'relative'
+        }}>
+          <SiBluesky />
+        </IconEl>
+      )
+    case 'mastodon':
+      return (
+        <IconEl {...props} className={`icon-${props.name}`} style={{
+          top: '1px',
+          position: 'relative'
+        }}>
+          <SiMastodon />
+        </IconEl>
+      )
+    case 'website':
+      return (
+        <IconEl {...props} className={`icon-${props.name}`} style={{
+          top: '1px',
+          position: 'relative'
+        }}>
+          <FaLink />
+        </IconEl>
+      )
+    default:
+      return (
+        <IconEl {...props} className={`icon-${props.name}`}>
+          {props.text ? <span>{props.text}</span> : null}
+        </IconEl>
+      )
+  }
+};
 
 Icon.propTypes = {
   name: string.isRequired,

--- a/lib/ui/templates/PeopleTpl.js
+++ b/lib/ui/templates/PeopleTpl.js
@@ -195,12 +195,15 @@ export const pageQuery = graphql`
           id
           html
           frontmatter {
+            bluesky
             fname
             github
             lname
+            mastodon
             quote
             score
             twitter
+            website
             uid
             avatar {
               childImageSharp {
@@ -235,12 +238,15 @@ export const pageQuery = graphql`
           id
           html
           frontmatter {
+            bluesky
             fname
             github
             lname
+            mastodon
             quote
             score
             twitter
+            website
             uid
             avatar {
               childImageSharp {
@@ -275,12 +281,15 @@ export const pageQuery = graphql`
           id
           html
           frontmatter {
+            bluesky
             fname
             github
             lname
+            mastodon
             quote
             score
             twitter
+            website
             uid
             avatar {
               childImageSharp {

--- a/lib/ui/templates/ofPeople/Person.js
+++ b/lib/ui/templates/ofPeople/Person.js
@@ -69,7 +69,16 @@ const PersonLinks = styled.div`
 const Member = props => {
   const { defaultAvatar } = props;
   const { frontmatter } = props.data;
-  const { avatar, fname, github, lname, twitter } = frontmatter;
+  const {
+    avatar,
+    bluesky,
+    fname,
+    github,
+    lname,
+    mastodon,
+    twitter,
+    website
+  } = frontmatter;
   return (
     <Person onClick={props.toggleModal} role="button">
       <PersonPic hasAvatar={avatar}>
@@ -82,12 +91,42 @@ const Member = props => {
           <span>{fname}</span> <span>{lname}</span>
         </PersonName>
         <PersonLinks>
+          {website ? (
+            <Action
+              onClick={e => e.stopPropagation()}
+              href={`https://${website}/`}
+              rel="external noopener noreferrer"
+              target="_blank"
+            >
+              <Icon name="website" size="s" />
+            </Action>
+          ) : null}
+          {bluesky ? (
+            <Action
+              onClick={e => e.stopPropagation()}
+              href={`https://bsky.app/profile/${bluesky}`}
+              rel="external noopener noreferrer"
+              target="_blank"
+            >
+              <Icon name="bluesky" size="s" />
+            </Action>
+          ) : null}
+          {mastodon ? (
+            <Action
+              onClick={e => e.stopPropagation()}
+              href={`https://${mastodon}`}
+              rel="external noopener noreferrer"
+              target="_blank"
+            >
+              <Icon name="mastodon" size="s" />
+            </Action>
+          ) : null}
           {twitter ? (
             <Action
               onClick={e => e.stopPropagation()}
               href={`https://twitter.com/${twitter}`}
-              rel="external"
-              target="_blank noreferrer nofollow"
+              rel="external noopener noreferrer"
+              target="_blank"
             >
               <Icon name="twitter" size="s" />
             </Action>
@@ -96,8 +135,8 @@ const Member = props => {
             <Action
               onClick={e => e.stopPropagation()}
               href={`https://github.com/${github}`}
-              rel="external"
-              target="_blank noreferrer nofollow"
+              rel="external noopener noreferrer"
+              target="_blank"
             >
               <Icon name="github" size="s" />
             </Action>

--- a/lib/ui/templates/ofPeople/PersonModal.js
+++ b/lib/ui/templates/ofPeople/PersonModal.js
@@ -60,7 +60,17 @@ const PersonSocial = styled.div`
 const Member = props => {
   const { defaultAvatar } = props;
   const { frontmatter, html } = props.data;
-  const { avatar, fname, github, lname, quote, twitter } = frontmatter;
+  const {
+    avatar,
+    bluesky,
+    fname,
+    github,
+    lname,
+    mastodon,
+    quote,
+    twitter,
+    website
+  } = frontmatter;
   return (
     <Modal toggleModal={props.toggleModal}>
       <Person>
@@ -78,12 +88,51 @@ const Member = props => {
           </PersonBio>
           <PersonQuote>{quote}</PersonQuote>
           <PersonSocial>
-            <Action href={`https://github.com/${github}`} target="_blank">
-              <Icon name="github" /> GitHub
-            </Action>
-            <Action href={`https://twitter.com/${twitter}`} target="_blank">
-              <Icon name="twitter" /> Twitter
-            </Action>
+            {website && (
+              <Action
+                href={`https://${website}/`}
+                rel="external noopener noreferrer"
+                target="_blank"
+              >
+                <Icon name="website" /> Website
+              </Action>
+            )}
+            {bluesky && (
+              <Action
+                href={`https://bsky.app/profile/${bluesky}`}
+                rel="external noopener noreferrer"
+                target="_blank"
+              >
+                <Icon name="bluesky" /> Bluesky
+              </Action>
+            )}
+            {mastodon && (
+              <Action
+                href={`https://${mastodon}`}
+                rel="external noopener noreferrer"
+                target="_blank"
+              >
+                <Icon name="mastodon" /> Mastodon
+              </Action>
+            )}
+            {twitter && (
+              <Action
+                href={`https://twitter.com/${twitter}`}
+                rel="external noopener noreferrer"
+                target="_blank"
+              >
+                <Icon name="twitter" /> Twitter
+              </Action>
+            )}
+            {github && (
+              <Action
+                href={`https://github.com/${github}`}
+                rel="external noopener noreferrer"
+                target="_blank"
+              >
+                <Icon name="github" /> GitHub
+              </Action>
+            )}
           </PersonSocial>
         </PersonDetails>
       </Person>

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-helmet": "6.1.0",
+    "react-icons": "^5.3.0",
     "react-plx": "1.3.17",
     "styled-components": "5.3.3"
   },

--- a/src/pages/people/bios/fatima-khalid.md
+++ b/src/pages/people/bios/fatima-khalid.md
@@ -8,6 +8,9 @@ role:
   - member: false
   - accomplice: false
 avatar: fatima-khalid.jpg
+website: 
+bluesky: 
+mastodon: 
 twitter: sugaroverflow
 github: sugaroverflow
 quote: Thank you for literally keeping everything from falling apart - Matt Stempeck

--- a/src/pages/people/bios/ian-anderson.md
+++ b/src/pages/people/bios/ian-anderson.md
@@ -8,6 +8,9 @@ role:
   - member: true
   - accomplice: false
 avatar: ian-anderson.jpg
+website: 
+bluesky: 
+mastodon: 
 twitter: senorinfinito
 github: ijanderso
 quote: 

--- a/src/pages/people/bios/jason-miller.md
+++ b/src/pages/people/bios/jason-miller.md
@@ -8,6 +8,9 @@ role:
   - member: false
   - accomplice: false
 avatar: 
+website: 
+bluesky: 
+mastodon: 
 twitter: millllllllllz
 github: JasonMiller
 quote: 

--- a/src/pages/people/bios/joanna-bogusz.md
+++ b/src/pages/people/bios/joanna-bogusz.md
@@ -8,6 +8,9 @@ role:
   - member: false
   - accomplice: true
 avatar: joanna-bogusz.jpg
+website: 
+bluesky: 
+mastodon: 
 twitter: 
 github: 
 quote: 

--- a/src/pages/people/bios/julia-smith.md
+++ b/src/pages/people/bios/julia-smith.md
@@ -8,6 +8,9 @@ role:
   - member: false
   - accomplice: true
 avatar: julia-smith.png
+website: 
+bluesky: 
+mastodon: 
 twitter: smythological
 github: julia-smith
 quote: OPPORTUNITY, n. A favorable occasion for grasping a disappointment. – Ambrose Bierce

--- a/src/pages/people/bios/justin-reese.md
+++ b/src/pages/people/bios/justin-reese.md
@@ -8,6 +8,9 @@ role:
   - member: false
   - accomplice: true
 avatar: justin-reese.jpg
+website: 
+bluesky: 
+mastodon: 
 twitter: reefdog
 github: reefdog
 quote: “The story was gradually taking shape. Pilon liked it this way. It ruined a story to have it all come out quickly. The good story lay in half-told things which must be filled in out of the hearer’s own experiences.” — Tortilla Flat

--- a/src/pages/people/bios/kate-darling.md
+++ b/src/pages/people/bios/kate-darling.md
@@ -8,6 +8,9 @@ role:
   - member: false
   - accomplice: false
 avatar: kate-darling.jpg
+website: 
+bluesky: 
+mastodon: 
 twitter: grok_
 github: grok
 quote: Quick someone give me a good quote

--- a/src/pages/people/bios/kavya-sukumar.md
+++ b/src/pages/people/bios/kavya-sukumar.md
@@ -8,6 +8,9 @@ role:
   - member: true
   - accomplice: true
 avatar: kavya-sukumar.jpg
+website: 
+bluesky: 
+mastodon: 
 twitter: kavyasukumar
 github: kavyasukumar
 quote: She is a diversity lottery - A recruiter who accidentally cc'ed me on an internal mail about my job application

--- a/src/pages/people/bios/laurian-gridinoc.md
+++ b/src/pages/people/bios/laurian-gridinoc.md
@@ -8,6 +8,9 @@ role:
   - member: false
   - accomplice: true
 avatar: laurian-gridinoc.jpg
+website: 
+bluesky: 
+mastodon: 
 twitter: gridinoc
 github: Laurian
 quote: Puisque nos dieux et nos espoirs ne sont plus que scientifiques, pourquoi nos amours ne le deviendraient-ils pas également? — Auguste Villiers de l’Isle-Adam, L’Ève future

--- a/src/pages/people/bios/lou-huang.md
+++ b/src/pages/people/bios/lou-huang.md
@@ -8,13 +8,15 @@ role:
   - member: true
   - accomplice: true
 avatar: lou-huang.jpg
-twitter: saikofish
+website: louhuang.com
+bluesky: louh.bsky.social
+mastodon: jawns.club/@lou
+# twitter: saikofish
 github: louh
 quote: Unlike the rest of you losers, I’ve made at least 20% of the shots I didn’t take
 score: 1
 ---
 
-Lou is an open source software developer, user interface engineer, urban designer, recovering architect and professional internet trickster based in Brooklyn, NY. He is the founder and CEO of Streetmix, a collaborative urban design platform.
+Lou is an open source software developer, user interface engineer, urban designer, recovering architect and professional internet trickster based in Philadelphia, PA. He is the founder of [Streetmix](https://streetmix.net/), a collaborative urban design platform.
 
-He is currently serving as Bad Idea Factory’s Treasure Goblin and works on a number of frivolous projects under the guise of secretly undermining capitalism. Sometimes he will stream livecoding and video games on [Twitch](https://www.twitch.tv/saikofish).
-
+He is currently serving as Bad Idea Factory’s Undersecretary of the Interior and works on a number of frivolous projects under the guise of secretly undermining capitalism.

--- a/src/pages/people/bios/margo-dunlap.md
+++ b/src/pages/people/bios/margo-dunlap.md
@@ -8,6 +8,9 @@ role:
   - member: false
   - accomplice: true
 avatar: margo-dunlap.jpg
+website: 
+bluesky: 
+mastodon: 
 twitter: MargoDunlap
 github: margoyle
 quote: 

--- a/src/pages/people/bios/mark-boas.md
+++ b/src/pages/people/bios/mark-boas.md
@@ -8,6 +8,9 @@ role:
   - member: true
   - accomplice: true
 avatar: mark-boas.jpg
+website: 
+bluesky: 
+mastodon: 
 twitter: maboa
 github: maboa
 quote: Well, in that case, sir, I hope you will not object if I also offer the doctor my most enthusiastic contrafibularities – Sir Edmund Blackadder

--- a/src/pages/people/bios/matt-stempeck.md
+++ b/src/pages/people/bios/matt-stempeck.md
@@ -8,6 +8,9 @@ role:
   - member: true
   - accomplice: true
 avatar: matt-stempeck.jpg
+website: 
+bluesky: 
+mastodon: 
 twitter: mstem
 github: mstem
 quote: 

--- a/src/pages/people/bios/mike-tigas.md
+++ b/src/pages/people/bios/mike-tigas.md
@@ -8,6 +8,9 @@ role:
   - member: false
   - accomplice: false
 avatar: mike-tigas.jpg
+website: 
+bluesky: 
+mastodon: 
 twitter: mtigas
 github: mtigas
 quote: ¯\_(ツ)_/¯

--- a/src/pages/people/bios/paul-schultz.md
+++ b/src/pages/people/bios/paul-schultz.md
@@ -8,6 +8,9 @@ role:
   - member: false
   - accomplice: false
 avatar: paul-schultz.jpg
+website: 
+bluesky: 
+mastodon: 
 twitter: 
 github: paulwschultz
 quote: All you have to do is click the right amount of buttons. - Sean (Day[9]) Plott

--- a/src/pages/people/bios/piotr-fedorczyk.md
+++ b/src/pages/people/bios/piotr-fedorczyk.md
@@ -8,6 +8,9 @@ role:
   - member: false
   - accomplice: true
 avatar: piotr-fedorczyk.png
+website: 
+bluesky: 
+mastodon: 
 twitter: presentday
 github: piotrf
 quote: I have no regrets

--- a/src/pages/people/bios/ted-han.md
+++ b/src/pages/people/bios/ted-han.md
@@ -8,6 +8,9 @@ role:
   - member: false
   - accomplice: true
 avatar: ted-han.jpg
+website: 
+bluesky: 
+mastodon: 
 twitter: knowtheory
 github: knowtheory
 quote: Ted Han could not be reached for comment

--- a/yarn.lock
+++ b/yarn.lock
@@ -9803,6 +9803,11 @@ react-helmet@6.1.0:
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
 
+react-icons@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-5.3.0.tgz#ccad07a30aebd40a89f8cfa7d82e466019203f1c"
+  integrity sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==
+
 react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
People on [this page](https://biffud.com/people) can now have links to a personal website, or to Bluesky and Mastodon profiles.

Directory:

<img width="477" alt="Screenshot 2024-11-28 at 1 44 02 PM" src="https://github.com/user-attachments/assets/9d49fab5-1021-4633-a8e5-2e3e025b24c1">

Modal:

<img width="842" alt="Screenshot 2024-11-28 at 1 44 07 PM" src="https://github.com/user-attachments/assets/e3941ba4-b795-4f5b-9d08-86bf45b255a9">

## Additional changes

- Fix an issue where a missing Twitter handle will appear in the modal linking to an `@null` account.
- Implemented `react-icons` ([link](https://react-icons.github.io/react-icons/)) as opposed to generating a new icon font through IcoMoon, which doesn't even have Bluesky on there. This meant building out the `<Icon>` component with workarounds.
- When generating links, fix the `rel` attribute to properly use the `noopener noreferrer` values. (It was previously attached to `target` in the people directory, and completely missing in the modal.) I've removed `nofollow` because these links should make sense for SEO purposes.
- Updated my own personal bio which contained a lot of out-of-date and inaccurate information.