### PR TITLE
fix(PersonModal): margin style for certain breakpoints

### DIFF
--- a/lib/ui/templates/ofPeople/PersonModal.js
+++ b/lib/ui/templates/ofPeople/PersonModal.js
@@ -49,11 +49,11 @@ const PersonQuote = styled.div`
   ${setSpace("mvm")};
 `;
 const PersonSocial = styled.div`
-  & > *:not(:first-child) {
-    ${setSpace("mlm")};
+  & > * {
+    ${setSpace("mvx")};
   }
   & > *:not(:last-child) {
-    ${setSpace("mrm")};
+    ${setSpace("mrl")};
   }
 `;
 


### PR DESCRIPTION
On a person's modal, and on some viewport widths, contact/socials links look like this:

<img width="476" alt="Screenshot 2024-12-03 at 12 49 03 AM" src="https://github.com/user-attachments/assets/f15ea6d6-972d-4280-9fef-9bf606b142bc">

In this PR, make it do this instead:

<img width="469" alt="Screenshot 2024-12-03 at 12 48 30 AM" src="https://github.com/user-attachments/assets/857a03cd-6209-4f1a-aba6-d423292890d9">

(left margin removed in all links; right margin expanded; slight increase in line-height to account for line breaks.)