### PR TITLE
fix(people): sort order by last name

### DIFF
--- a/lib/ui/templates/PeopleTpl.js
+++ b/lib/ui/templates/PeopleTpl.js
@@ -183,7 +183,7 @@ export const pageQuery = graphql`query PeopleTplQuery($uid: String!) {
   }
   overlords: allMarkdownRemark(
     filter: {fileAbsolutePath: {regex: "//pages/people/bios/*/.*/*.md/"}, frontmatter: {role: {elemMatch: {overlord: {eq: true}}}}}
-    sort: {frontmatter: {score: DESC}}
+    sort: {frontmatter: {fname: ASC}}
   ) {
     edges {
       node {
@@ -217,7 +217,7 @@ export const pageQuery = graphql`query PeopleTplQuery($uid: String!) {
   }
   members: allMarkdownRemark(
     filter: {fileAbsolutePath: {regex: "//pages/people/bios/*/.*/*.md/"}, frontmatter: {role: {elemMatch: {member: {eq: true}}}}}
-    sort: {frontmatter: {score: DESC}}
+    sort: {frontmatter: {fname: ASC}}
   ) {
     edges {
       node {
@@ -251,7 +251,7 @@ export const pageQuery = graphql`query PeopleTplQuery($uid: String!) {
   }
   accomplices: allMarkdownRemark(
     filter: {fileAbsolutePath: {regex: "//pages/people/bios/*/.*/*.md/"}, frontmatter: {role: {elemMatch: {accomplice: {eq: true}}}}}
-    sort: [{frontmatter: {score: DESC}}, {frontmatter: {lname: ASC}}]
+    sort: {frontmatter: {fname: ASC}}
   ) {
     edges {
       node {


### PR DESCRIPTION
I don't know what the sort by `score` means since almost everyone has `1` (except for Mark and Annabel). It looks like this causes the published website to sort overlords by first name, then score, but if you're running a local version then all bets are off, it's sorted by random, then score. (With the exception of accomplices, which are sorted by _last_ name.)

I'm proposing to make this consistently sort by first name _only_ across all three categories and removing `score` from sort order which doesn't seem to serve a purpose (that I know of!)

I kind of like the option of sorting by random, to be honest, but that's not something I think gatsby/graphql can do. (We'd have to tell React to render items at random, which is also fine.)